### PR TITLE
auto_accept, and auto_settle, options added to Sender/Receiver constructor.

### DIFF
--- a/integration/int_3Ri_2BhaRi2_3Re_2BhaRe3/receiver.py
+++ b/integration/int_3Ri_2BhaRi2_3Re_2BhaRe3/receiver.py
@@ -15,8 +15,8 @@ class Receiver(MessagingHandler, threading.Thread):
     Receiver implementation of a Proton client that run as a thread.
     """
     def __init__(self, url, message_count, timeout=0, container_id=None, durable=False, save_messages=False,
-                 ignore_dups=False):
-        super(Receiver, self).__init__()
+                 ignore_dups=False, auto_accept=True, auto_settle=True):
+        super(Receiver, self).__init__(auto_accept=auto_accept, auto_settle=auto_settle)
         threading.Thread.__init__(self)
         self.url = url
         self.receiver = None

--- a/integration/int_3Ri_2BhaRi2_3Re_2BhaRe3/sender.py
+++ b/integration/int_3Ri_2BhaRi2_3Re_2BhaRe3/sender.py
@@ -22,8 +22,9 @@ class Sender(MessagingHandler, threading.Thread):
     lock = threading.Lock()
 
     def __init__(self, url, message_count, sender_id, message_size=1024, timeout=0,
-                 user_id=None, proton_option=AtLeastOnce(), use_unique_body=False):
-        super(Sender, self).__init__()
+                 user_id=None, proton_option=AtLeastOnce(), use_unique_body=False,
+                 auto_accept=True, auto_settle=True):
+        super(Sender, self).__init__(auto_accept=auto_accept, auto_settle=auto_settle)
         threading.Thread.__init__(self)
         self.url = url
         self.total = message_count


### PR DESCRIPTION
Adding this two parameters to constructors allows to use Sender and Receiver classes for multicast testing.